### PR TITLE
Use RedirectView in urlpatterns (needed for Django 1.5)

### DIFF
--- a/favicon/urls.py
+++ b/favicon/urls.py
@@ -3,5 +3,5 @@ from django.views.generic import TemplateView, RedirectView
 import conf
 
 urlpatterns = patterns('',
-    url(r'^favicon\.ico$', 'django.views.generic.simple.redirect_to', {'url': conf.FAVICON_PATH}, name='favicon'),
+    url(r'^favicon\.ico$', RedirectView.as_view(url=conf.FAVICON_PATH}), name='favicon'),
 )


### PR DESCRIPTION
'django.views.generic.simple.redirect_to' is not supported in Django 1.5

Use RedirectView.as_view instead.

The existing code was already importing RedirectView but still using the old 'django.views.generic.simple.redirect_to' in the url patterns. 
