### PR TITLE
Django 1.9 deprecation fix.

### DIFF
--- a/favicon/urls.py
+++ b/favicon/urls.py
@@ -3,5 +3,5 @@ from django.views.generic import TemplateView, RedirectView
 import conf
 
 urlpatterns = patterns('',
-    url(r'^favicon\.ico$', RedirectView.as_view(url=conf.FAVICON_PATH), name='favicon'),
+    url(r'^favicon\.ico$', RedirectView.as_view(url=conf.FAVICON_PATH, permanent=True), name='favicon'),
 )


### PR DESCRIPTION
Django was raising the following error: `RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.` Since this **should** be a permanent redirect, I went ahead and fixed it.